### PR TITLE
run `zig fmt`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,8 +27,8 @@ pub fn build(b: *std.build.Builder) void {
     run_step.dependOn(&run_cmd.step);
 
     const exe_tests = b.addTest("src/tests.zig");
-    // Lua 
-    addLuaLibrary(exe_tests, "" );
+    // Lua
+    addLuaLibrary(exe_tests, "");
 
     //
     exe_tests.setBuildMode(mode);
@@ -37,10 +37,10 @@ pub fn build(b: *std.build.Builder) void {
     test_step.dependOn(&exe_tests.step);
 }
 
-pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) void {
+pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: []const u8) void {
     var buf: [1024]u8 = undefined;
     // Lua headers + required source files
-    var path = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, "src/lua-5.4.3/src"}) catch unreachable;
+    var path = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, "src/lua-5.4.3/src" }) catch unreachable;
 
     exe.addIncludeDir(path);
     // C compile flags
@@ -49,13 +49,13 @@ pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) vo
         "-O2",
     };
     for (luaFiles) |luaFile| {
-        var cPath = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, luaFile}) catch unreachable;
+        var cPath = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, luaFile }) catch unreachable;
         exe.addCSourceFile(cPath, &flags);
     }
     exe.linkLibC();
 }
 
-const luaFiles = [_] []const u8{
+const luaFiles = [_][]const u8{
     "src/lua-5.4.3/src/lapi.c",
     "src/lua-5.4.3/src/lauxlib.c",
     "src/lua-5.4.3/src/lbaselib.c",

--- a/src/lua.zig
+++ b/src/lua.zig
@@ -13,9 +13,9 @@ pub const Lua = struct {
         registeredTypes: std.StringArrayHashMap([]const u8) = undefined,
 
         fn init(_allocator: std.mem.Allocator) LuaUserData {
-            return LuaUserData {
+            return LuaUserData{
                 .allocator = _allocator,
-                .registeredTypes = std.StringArrayHashMap([]const u8).init(_allocator)
+                .registeredTypes = std.StringArrayHashMap([]const u8).init(_allocator),
             };
         }
 
@@ -23,14 +23,14 @@ pub const Lua = struct {
             self.registeredTypes.clearAndFree();
         }
     };
-    
+
     L: *lualib.lua_State,
     ud: *LuaUserData,
 
     pub fn init(allocator: std.mem.Allocator) !Lua {
         var _ud = try allocator.create(LuaUserData);
         _ud.* = LuaUserData.init(allocator);
-        
+
         var _state = lualib.lua_newstate(alloc, _ud) orelse return error.OutOfMemory;
         var state = Lua{
             .L = _state,
@@ -675,8 +675,8 @@ pub const Lua = struct {
     }
 
     fn getUserData(L: ?*lualib.lua_State) *Lua.LuaUserData {
-        var ud : *anyopaque = undefined;
-        _ = lualib.lua_getallocf (L, @ptrCast([*c]?*anyopaque, &ud));
+        var ud: *anyopaque = undefined;
+        _ = lualib.lua_getallocf(L, @ptrCast([*c]?*anyopaque, &ud));
         const userData = @ptrCast(*Lua.LuaUserData, @alignCast(@alignOf(Lua.LuaUserData), ud));
         return userData;
     }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -666,7 +666,7 @@ test "Custom types II: set as global, get without ownership" {
 
     _ = try lua.newUserType(TestCustomType);
     // Creation from Zig
-    var ojjectum = try lua.createUserType(TestCustomType, .{42, 42.0, "life", true});
+    var ojjectum = try lua.createUserType(TestCustomType, .{ 42, 42.0, "life", true });
     defer lua.release(ojjectum);
 
     lua.set("zig", ojjectum);


### PR DESCRIPTION
I ran the `zig fmt` formatting command (using newest zig version `0.10.0-dev390+0866fa9d1`) in a local project for consistency, and thought you might want to have the repo be in canonical form too. If not, feel free to close this PR.

It's really just whitespace changes, though I inserted a trailing comma at one point to make it preserve a line break.