### PR TITLE
Wrapper type fixups regarding string terminators

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -27,8 +27,8 @@ pub fn build(b: *std.build.Builder) void {
     run_step.dependOn(&run_cmd.step);
 
     const exe_tests = b.addTest("src/tests.zig");
-    // Lua 
-    addLuaLibrary(exe_tests, "" );
+    // Lua
+    addLuaLibrary(exe_tests, "");
 
     //
     exe_tests.setBuildMode(mode);
@@ -37,10 +37,10 @@ pub fn build(b: *std.build.Builder) void {
     test_step.dependOn(&exe_tests.step);
 }
 
-pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) void {
+pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: []const u8) void {
     var buf: [1024]u8 = undefined;
     // Lua headers + required source files
-    var path = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, "src/lua-5.4.3/src"}) catch unreachable;
+    var path = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, "src/lua-5.4.3/src" }) catch unreachable;
 
     exe.addIncludeDir(path);
     // C compile flags
@@ -49,13 +49,13 @@ pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) vo
         "-O2",
     };
     for (luaFiles) |luaFile| {
-        var cPath = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, luaFile}) catch unreachable;
+        var cPath = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, luaFile }) catch unreachable;
         exe.addCSourceFile(cPath, &flags);
     }
     exe.linkLibC();
 }
 
-const luaFiles = [_] []const u8{
+const luaFiles = [_][]const u8{
     "src/lua-5.4.3/src/lapi.c",
     "src/lua-5.4.3/src/lauxlib.c",
     "src/lua-5.4.3/src/lbaselib.c",

--- a/src/lua.zig
+++ b/src/lua.zig
@@ -13,9 +13,9 @@ pub const Lua = struct {
         registeredTypes: std.StringArrayHashMap([]const u8) = undefined,
 
         fn init(_allocator: std.mem.Allocator) LuaUserData {
-            return LuaUserData {
+            return LuaUserData{
                 .allocator = _allocator,
-                .registeredTypes = std.StringArrayHashMap([]const u8).init(_allocator)
+                .registeredTypes = std.StringArrayHashMap([]const u8).init(_allocator),
             };
         }
 
@@ -23,14 +23,14 @@ pub const Lua = struct {
             self.registeredTypes.clearAndFree();
         }
     };
-    
+
     L: *lualib.lua_State,
     ud: *LuaUserData,
 
     pub fn init(allocator: std.mem.Allocator) !Lua {
         var _ud = try allocator.create(LuaUserData);
         _ud.* = LuaUserData.init(allocator);
-        
+
         var _state = lualib.lua_newstate(alloc, _ud) orelse return error.OutOfMemory;
         var state = Lua{
             .L = _state,
@@ -675,8 +675,8 @@ pub const Lua = struct {
     }
 
     fn getUserData(L: ?*lualib.lua_State) *Lua.LuaUserData {
-        var ud : *anyopaque = undefined;
-        _ = lualib.lua_getallocf (L, @ptrCast([*c]?*anyopaque, &ud));
+        var ud: *anyopaque = undefined;
+        _ = lualib.lua_getallocf(L, @ptrCast([*c]?*anyopaque, &ud));
         const userData = @ptrCast(*Lua.LuaUserData, @alignCast(@alignOf(Lua.LuaUserData), ud));
         return userData;
     }

--- a/src/lua.zig
+++ b/src/lua.zig
@@ -10,12 +10,12 @@ pub const lualib = @cImport({
 pub const Lua = struct {
     const LuaUserData = struct {
         allocator: std.mem.Allocator,
-        registeredTypes: std.StringArrayHashMap([]const u8) = undefined,
+        registeredTypes: std.StringArrayHashMap([:0]const u8) = undefined,
 
         fn init(_allocator: std.mem.Allocator) LuaUserData {
             return LuaUserData{
                 .allocator = _allocator,
-                .registeredTypes = std.StringArrayHashMap([]const u8).init(_allocator),
+                .registeredTypes = std.StringArrayHashMap([:0]const u8).init(_allocator),
             };
         }
 
@@ -40,7 +40,7 @@ pub const Lua = struct {
     }
 
     pub fn destroy(self: *Lua) void {
-        _ = lualib.lua_close(self.L);
+        lualib.lua_close(self.L);
         self.ud.destroy();
         var allocator = self.ud.allocator;
         allocator.destroy(self.ud);
@@ -72,18 +72,18 @@ pub const Lua = struct {
         self.run(cmd);
     }
 
-    pub fn run(self: *Lua, script: []const u8) void {
-        _ = lualib.luaL_loadstring(self.L, @ptrCast([*c]const u8, script));
+    pub fn run(self: *Lua, script: [*:0]const u8) void {
+        _ = lualib.luaL_loadstring(self.L, script);
         _ = lualib.lua_pcallk(self.L, 0, 0, 0, 0, null);
     }
 
-    pub fn set(self: *Lua, name: []const u8, value: anytype) void {
+    pub fn set(self: *Lua, name: [*:0]const u8, value: anytype) void {
         _ = push(self.L, value);
-        _ = lualib.lua_setglobal(self.L, @ptrCast([*c]const u8, name));
+        _ = lualib.lua_setglobal(self.L, name);
     }
 
-    pub fn get(self: *Lua, comptime T: type, name: []const u8) !T {
-        const typ = lualib.lua_getglobal(self.L, @ptrCast([*c]const u8, name));
+    pub fn get(self: *Lua, comptime T: type, name: [*:0]const u8) !T {
+        const typ = lualib.lua_getglobal(self.L, name);
         if (typ != lualib.LUA_TNIL) {
             return try pop(T, self.L);
         } else {
@@ -91,8 +91,8 @@ pub const Lua = struct {
         }
     }
 
-    pub fn getResource(self: *Lua, comptime T: type, name: []const u8) !T {
-        const typ = lualib.lua_getglobal(self.L, @ptrCast([*c]const u8, name));
+    pub fn getResource(self: *Lua, comptime T: type, name: [*:0]const u8) !T {
+        const typ = lualib.lua_getglobal(self.L, name);
         if (typ != lualib.LUA_TNIL) {
             return try popResource(T, self.L);
         } else {
@@ -106,16 +106,15 @@ pub const Lua = struct {
     }
 
     pub fn createUserType(self: *Lua, comptime T: type, params: anytype) !Ref(T) {
-        var metaTableName: []const u8 = undefined;
+        // Find the corresponding metatable name
+        var metaTableName: [:0]const u8 = if (getUserData(self.L).registeredTypes.get(@typeName(T))) |name|
+            name
+        else
+            return error.unregistered_type;
         // Allocate memory
         var ptr = @ptrCast(*T, @alignCast(@alignOf(T), lualib.lua_newuserdata(self.L, @sizeOf(T))));
         // set its metatable
-        if (getUserData(self.L).registeredTypes.get(@typeName(T))) |name| {
-            metaTableName = name;
-        } else {
-            return error.unregistered_type;
-        }
-        _ = lualib.luaL_getmetatable(self.L, @ptrCast([*c]const u8, metaTableName[0..]));
+        _ = lualib.luaL_getmetatable(self.L, metaTableName.ptr);
         _ = lualib.lua_setmetatable(self.L, -2);
         // (3) init & copy wrapped object
         // Call init
@@ -144,8 +143,8 @@ pub const Lua = struct {
     pub fn newUserType(self: *Lua, comptime T: type) !void {
         comptime var hasInit: bool = false;
         comptime var hasDestroy: bool = false;
-        comptime var metaTblName: [1024]u8 = undefined;
-        _ = comptime try std.fmt.bufPrint(metaTblName[0..], "{s}", .{@typeName(T)});
+        comptime var metaTblNameBuffer: [1024]u8 = undefined;
+        comptime var metaTblName = comptime try std.fmt.bufPrintZ(&metaTblNameBuffer, "{s}", .{@typeName(T)});
         // Init Lua states
         comptime var allocFuns = struct {
             fn new(L: ?*lualib.lua_State) callconv(.C) c_int {
@@ -156,7 +155,7 @@ pub const Lua = struct {
                 // (2) create Lua object
                 var ptr = @ptrCast(*T, @alignCast(@alignOf(T), lualib.lua_newuserdata(L, @sizeOf(T))));
                 // set its metatable
-                _ = lualib.luaL_getmetatable(L, @ptrCast([*c]const u8, metaTblName[0..]));
+                _ = lualib.luaL_getmetatable(L, metaTblName[0..]);
                 _ = lualib.lua_setmetatable(L, -2);
                 // (3) init & copy wrapped object
                 caller.call(T.init) catch unreachable;
@@ -170,13 +169,13 @@ pub const Lua = struct {
             }
 
             fn gc(L: ?*lualib.lua_State) callconv(.C) c_int {
-                var ptr = @ptrCast(*T, @alignCast(@alignOf(T), lualib.luaL_checkudata(L, 1, @ptrCast([*c]const u8, metaTblName[0..]))));
+                var ptr = @ptrCast(*T, @alignCast(@alignOf(T), lualib.luaL_checkudata(L, 1, metaTblName.ptr)));
                 ptr.destroy();
                 return 0;
             }
         };
         // Create metatable
-        _ = lualib.luaL_newmetatable(self.L, @ptrCast([*c]const u8, metaTblName[0..]));
+        _ = lualib.luaL_newmetatable(self.L, metaTblName.ptr);
         // Metatable.__index = metatable
         lualib.lua_pushvalue(self.L, -1);
         lualib.lua_setfield(self.L, -2, "__index");
@@ -199,7 +198,8 @@ pub const Lua = struct {
                                 comptime var field = @field(T, decl.name);
                                 const Caller = ZigCallHelper(@TypeOf(field));
                                 Caller.pushFunctor(self.L, field) catch unreachable;
-                                lualib.lua_setfield(self.L, -2, @ptrCast([*c]const u8, decl.name));
+                                const decl_name_z = comptime addZ(u8, decl.name);
+                                lualib.lua_setfield(self.L, -2, @as([*:0]const u8, decl_name_z.ptr));
                             }
                         },
                         else => {},
@@ -220,10 +220,10 @@ pub const Lua = struct {
         lualib.lua_setfield(self.L, -2, "new");
 
         // Set as global ('require' requires luaopen_{libraname} named static C functionsa and we don't want to provide one)
-        _ = lualib.lua_setglobal(self.L, @ptrCast([*c]const u8, metaTblName[0..]));
+        _ = lualib.lua_setglobal(self.L, metaTblName.ptr);
 
         // Store in the registry
-        try getUserData(self.L).registeredTypes.put(@typeName(T), metaTblName[0..]);
+        try getUserData(self.L).registeredTypes.put(@typeName(T), metaTblName);
     }
 
     pub fn Function(comptime T: type) type {
@@ -405,23 +405,31 @@ pub const Lua = struct {
                     switch (@typeInfo(PointerInfo.child)) {
                         .Array => |childInfo| {
                             if (childInfo.child == u8) {
-                                _ = lualib.lua_pushstring(L, @ptrCast([*c]const u8, value));
-                            } else {
-                                @compileError("invalid type: '" ++ @typeName(T) ++ "'");
+                                if (childInfo.sentinel) |sentinel| {
+                                    if (sentinel == 0) {
+                                        _ = lualib.lua_pushstring(L, @as([*:0]const u8, value));
+                                        return;
+                                    }
+                                }
                             }
+                            @compileError("invalid type: '" ++ @typeName(T) ++ "'");
                         },
                         .Struct => {
                             unreachable;
                         },
-                        else => @compileError("BAszomalassan"),
+                        else => @compileError("invalid type: '" ++ @typeName(T) ++ "'"),
                     }
                 },
                 .Many => {
                     if (PointerInfo.child == u8) {
-                        _ = lualib.lua_pushstring(L, @ptrCast([*c]const u8, value));
-                    } else {
-                        @compileError("invalid type: '" ++ @typeName(T) ++ "'. Typeinfo: '" ++ @typeInfo(PointerInfo.child) ++ "'");
+                        if (PointerInfo.sentinel) |sentinel| {
+                            if (sentinel == 0) {
+                                _ = lualib.lua_pushstring(L, @as([*:0]const u8, value));
+                                return;
+                            }
+                        }
                     }
+                    @compileError("invalid type: '" ++ @typeName(T) ++ "'. child type: '" ++ @typeName(PointerInfo.child) ++ "'");
                 },
                 .C => {
                     if (PointerInfo.child == u8) {
@@ -472,7 +480,7 @@ pub const Lua = struct {
                     // [] const u8 case
                     if (PointerInfo.child == u8 and PointerInfo.is_const) {
                         var len: usize = 0;
-                        var ptr = lualib.lua_tolstring(L, -1, @ptrCast([*c]usize, &len));
+                        var ptr = lualib.lua_tolstring(L, -1, &len);
                         var result: T = ptr[0..len];
                         return result;
                     } else @compileError("Only '[]const u8' (aka string) is supported allocless.");
@@ -480,7 +488,7 @@ pub const Lua = struct {
                 .One => {
                     var optionalTbl = getUserData(L).registeredTypes.get(@typeName(PointerInfo.child));
                     if (optionalTbl) |tbl| {
-                        var result = @ptrCast(T, @alignCast(@alignOf(PointerInfo.child), lualib.luaL_checkudata(L, -1, @ptrCast([*c]const u8, tbl[0..]))));
+                        var result = @ptrCast(T, @alignCast(@alignOf(PointerInfo.child), lualib.luaL_checkudata(L, -1, tbl)));
                         return result;
                     } else {
                         return error.invalidType;
@@ -651,7 +659,7 @@ pub const Lua = struct {
             };
 
             pub fn pushFunctor(L: ?*lualib.lua_State, func: funcType) !void {
-                const funcPtrAsInt = @intCast(c_longlong, @ptrToInt(func));
+                const funcPtrAsInt = @intCast(lualib.lua_Integer, @ptrToInt(func));
                 lualib.lua_pushinteger(L, funcPtrAsInt);
 
                 const cfun = struct {
@@ -675,9 +683,9 @@ pub const Lua = struct {
     }
 
     fn getUserData(L: ?*lualib.lua_State) *Lua.LuaUserData {
-        var ud: *anyopaque = undefined;
-        _ = lualib.lua_getallocf(L, @ptrCast([*c]?*anyopaque, &ud));
-        const userData = @ptrCast(*Lua.LuaUserData, @alignCast(@alignOf(Lua.LuaUserData), ud));
+        var ud: ?*anyopaque = undefined;
+        _ = lualib.lua_getallocf(L, &ud);
+        const userData = @ptrCast(*Lua.LuaUserData, @alignCast(@alignOf(Lua.LuaUserData), ud.?));
         return userData;
     }
 
@@ -703,6 +711,14 @@ pub const Lua = struct {
             // When osize is some other value, Lua is allocating memory for something else.
             return (userData.allocator.alignedAlloc(u8, c_alignment, nsize) catch return null).ptr;
         }
+    }
+
+    // Credit: ifreund@github.com in https://github.com/ziglang/zig/issues/9182#issuecomment-867122969
+    fn addZ(comptime T: type, comptime s: []const T) [:0]T {
+        var arr: [s.len + 1]T = undefined;
+        std.mem.copy(T, &arr, s);
+        arr[s.len] = 0;
+        return arr[0..s.len :0];
     }
 };
 

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -666,7 +666,7 @@ test "Custom types II: set as global, get without ownership" {
 
     _ = try lua.newUserType(TestCustomType);
     // Creation from Zig
-    var ojjectum = try lua.createUserType(TestCustomType, .{42, 42.0, "life", true});
+    var ojjectum = try lua.createUserType(TestCustomType, .{ 42, 42.0, "life", true });
     defer lua.release(ojjectum);
 
     lua.set("zig", ojjectum);

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -50,12 +50,12 @@ test "set/get string" {
     var lua = try Lua.init(std.testing.allocator);
     defer lua.destroy();
 
-    var strMany: [*]const u8 = "macilaci";
+    var strMany: [*:0]const u8 = "macilaci";
     var strSlice: []const u8 = "macilaic";
     var strOne = "macilaci";
     var strC: [*c]const u8 = "macilaci";
 
-    const cstrMany: [*]const u8 = "macilaci";
+    const cstrMany: [*:0]const u8 = "macilaci";
     const cstrSlice: []const u8 = "macilaic";
     const cstrOne = "macilaci";
     const cstrC: [*c]const u8 = "macilaci";
@@ -63,12 +63,12 @@ test "set/get string" {
     lua.set("stringMany", strMany);
     lua.set("stringSlice", strSlice);
     lua.set("stringOne", strOne);
-    lua.set("stringC", strC);
+    lua.set("stringC", std.mem.span(strC));
 
     lua.set("cstringMany", cstrMany);
     lua.set("cstringSlice", cstrSlice);
     lua.set("cstringOne", cstrOne);
-    lua.set("cstringC", cstrC);
+    lua.set("cstringC", std.mem.span(cstrC));
 
     const retStrMany = try lua.get([]const u8, "stringMany");
     const retCStrMany = try lua.get([]const u8, "cstringMany");


### PR DESCRIPTION
(based on #2 , but if that is rejected it's trivial to rebase on main)

The Lua API explicitly states it expects 0-terminated strings ("null-terminated") at several points.
These changes express this using Zig's sentinel termination syntax (`[:0]` for 0-terminated slice, `[*:0]` for pointer-to-many with 0-termination).

I also removed all `@ptrCast` to `[*c]` types, as they are non-helpful. All pointers already coerce to these types where sensible, so they can only hide errors.
These types only exist for `translate-c` and `@cImport` to be less explicit about pointer sizes. When writing code manually, it's preferred to be explicit about what size pointers are (i.e. `*T` vs `[*]T` vs optional, and terminator info).

I had to adjust one test a bit, because it included pushing strings without information about their 0-terminator.
I've adapted the case with `[*]const u8` to instead use the type `[*:0]const u8` (which string literals are already compatible with).
On `[*c] const u8` I've used `std.mem.span`, just to showcase it, which looks for the 0-terminator we know is there. The `[*c] const u8` type in general doesn't guarantee that it's a safe operation however.