### PR TITLE
Remove redundant install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ pub fn build(b: *std.build.Builder) void {
 ...
   // Exe part
   exe.addPackage(.{ .name = "lua", .path = .{ .path="third_party/zoltan/src/lua.zig" }});
-  addLuaLib(exe, "third_party/zoltan/");
+  addLuaLib(exe);
 ...
   // Test part
   const lua_tests = b.addTest("third_party/zoltan/src/tests.zig");
-  addLuaLib(lua_tests, "third_party/zoltan/");
+  addLuaLib(lua_tests);
   lua_tests.setBuildMode(mode);
 ```
 You can found an example integration [here](https://github.com/ranciere/zoltan_example_app).

--- a/build.zig
+++ b/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.build.Builder) void {
     const mode = b.standardReleaseOptions();
 
     const exe = b.addExecutable("zoltan", "src/lua.zig");
-    addLuaLibrary(exe, "");
+    addLuaLibrary(exe);
     exe.setTarget(target);
     exe.setBuildMode(mode);
     exe.install();
@@ -28,7 +28,7 @@ pub fn build(b: *std.build.Builder) void {
 
     const exe_tests = b.addTest("src/tests.zig");
     // Lua 
-    addLuaLibrary(exe_tests, "" );
+    addLuaLibrary(exe_tests);
 
     //
     exe_tests.setBuildMode(mode);
@@ -37,10 +37,14 @@ pub fn build(b: *std.build.Builder) void {
     test_step.dependOn(&exe_tests.step);
 }
 
-pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) void {
+fn thisDir() []const u8 {
+    return std.fs.path.dirname(@src().file) orelse ".";
+}
+
+pub fn addLuaLibrary(exe: *std.build.LibExeObjStep) void {
     var buf: [1024]u8 = undefined;
     // Lua headers + required source files
-    var path = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, "src/lua-5.4.3/src"}) catch unreachable;
+    var path = std.fmt.bufPrint(buf[0..], "{s}/{s}", .{ thisDir(), "src/lua-5.4.3/src"}) catch unreachable;
 
     exe.addIncludeDir(path);
     // C compile flags
@@ -49,7 +53,7 @@ pub fn addLuaLibrary(exe: *std.build.LibExeObjStep, installPath: [] const u8) vo
         "-O2",
     };
     for (luaFiles) |luaFile| {
-        var cPath = std.fmt.bufPrint(buf[0..], "{s}{s}", .{ installPath, luaFile}) catch unreachable;
+        var cPath = std.fmt.bufPrint(buf[0..], "{s}/{s}", .{ thisDir(), luaFile}) catch unreachable;
         exe.addCSourceFile(cPath, &flags);
     }
     exe.linkLibC();


### PR DESCRIPTION
Although not really well documented, it is possible to get the absolute
path to the current `.zig` file using the `@src().file` comptime known
value.